### PR TITLE
fix: calculateTimeDuration

### DIFF
--- a/src/components/chart/rechartsTimeSeries.tsx
+++ b/src/components/chart/rechartsTimeSeries.tsx
@@ -251,7 +251,8 @@ function RechartsTimeSeries(props: RechartsTimeSeriesProps) {
 
     const durationInDays =
       // eslint-disable-next-line no-magic-numbers
-      props.timeSeries.length > 0 ? timeDifference / 60 / 60 / 24 : 0
+      props.timeSeries.length > 0 ? timeDifference / (1000 * 60 * 60 * 24) : 0
+
     return durationInDays
   }
 


### PR DESCRIPTION
## Issue:
- Data within one day was not formatted properly in `RechartsTimeSeries` component

## Change:
- Update the calculateTimeDuration function to do the conversion for timestamp in milliseconds

## Screenshots
### Before
<img width="1036" alt="Screenshot 2024-02-29 at 12 35 06 PM" src="https://github.com/dragonscale-ai/ui-components/assets/103023797/1b0b065b-074c-42c3-8fa1-7074dfcf7e23">

### After
<img width="1023" alt="Screenshot 2024-02-29 at 12 34 41 PM" src="https://github.com/dragonscale-ai/ui-components/assets/103023797/e9bf5256-e3b7-4435-a5fb-92692ca8056e">
