### PR TITLE
docs: add step for adding styles in quick start

### DIFF
--- a/docs/quickStart.stories.mdx
+++ b/docs/quickStart.stories.mdx
@@ -18,7 +18,13 @@ Follow these steps to quickly integrate Rustic UI Components into your applicati
    npm install @mui/material @emotion/react @emotion/styled
    ```
 
-2. Start integrating Rustic UI Components into your application by importing the necessary components. Below is a sample code snippet demonstrating how to use the MessageSpace component to render messages:
+2. Add the following to the top of your `index.css` file to import the CSS styles:
+
+   ```
+   @import '@rustic-ai/ui-components/dist/index.css';
+   ```
+
+3. Start integrating Rustic UI Components into your application by importing the necessary components. Below is a sample code snippet demonstrating how to use the MessageSpace component to render messages:
 
    ```
    import {


### PR DESCRIPTION
## Issue:
- CSS styles are not applied automatically.

## Change:
- Add a step to the Quick Start documentation for adding the component styling.

## Screenshots
### Before
<img width="789" alt="Screenshot 2024-02-29 at 4 00 48 PM" src="https://github.com/dragonscale-ai/ui-components/assets/111031789/caf458ff-10c3-4891-8142-80dd148a9333">

### After
<img width="789" alt="Screenshot 2024-02-29 at 3 59 48 PM" src="https://github.com/dragonscale-ai/ui-components/assets/111031789/255bc54c-a824-44ae-b9e6-f614eb3d2962">
