### PR TITLE
refactor: move time-related functions to helper file

### DIFF
--- a/cypress/unit/calculateTimeDiffInDays.cy.ts
+++ b/cypress/unit/calculateTimeDiffInDays.cy.ts
@@ -1,0 +1,39 @@
+import { calculateTimeDiffInDays } from '../../src/components/helper'
+
+describe('calculateTimeDiffInDays function', () => {
+  it('calculates the time difference correctly for duration that is exactly 1 day', () => {
+    const startTimestamp = 1627679200000
+    const endTimestamp = 1627765600000
+
+    const differenceInDays = calculateTimeDiffInDays(
+      startTimestamp,
+      endTimestamp
+    )
+
+    expect(differenceInDays).to.equal(1) // Expect the difference to be 1 day
+  })
+
+  it('calculates the time difference in days correctly for duration that is less than one day', () => {
+    const startTimestamp = 1627679200000
+    const endTimestamp = 1627686600000
+
+    const differenceInDays = calculateTimeDiffInDays(
+      startTimestamp,
+      endTimestamp
+    )
+
+    expect(differenceInDays).to.lessThan(1)
+  })
+
+  it('calculates the time difference in days correctly for duration that is more than one day', () => {
+    const startTimestamp = 1627679200000
+    const endTimestamp = 1628687000000
+
+    const differenceInDays = calculateTimeDiffInDays(
+      startTimestamp,
+      endTimestamp
+    )
+
+    expect(differenceInDays).to.greaterThan(1)
+  })
+})

--- a/cypress/unit/formatTimestamp.cy.ts
+++ b/cypress/unit/formatTimestamp.cy.ts
@@ -2,35 +2,23 @@ import { formatTimestamp, TimeFormat } from '../../src/components/helper'
 
 describe('formatTimestamp', () => {
   it("should return a string representing the time in the user's locale", () => {
-    const time = 1634567890
+    const timestamp = 1634567890000
     const format = TimeFormat.HOUR
-    const result = formatTimestamp(time, format)
+    const result = formatTimestamp(timestamp, format)
     expect(typeof result).to.eq('string')
   })
 
   it("should return a string with the hour and minute in the user's locale when format is TimeFormat.HOUR", () => {
-    const time = 1634567890
+    const timestamp = 1634567890000
     const format = TimeFormat.HOUR
-    const result = formatTimestamp(time, format)
+    const result = formatTimestamp(timestamp, format)
     expect(result).to.match(/\d{1,2}:\d{2}\s(AM|PM)/)
   })
 
   it("should return a string with the month and date in the user's locale when format is TimeFormat.MONTH_DATE", () => {
-    const time = 1634567890
+    const timestamp = 1634567890000
     const format = TimeFormat.MONTH_DATE
-    const result = formatTimestamp(time, format)
+    const result = formatTimestamp(timestamp, format)
     expect(result).to.match(/[A-Za-z]{3}\s\d{1,2}/)
-  })
-
-  it('should format the timestamp in milliseconds properly', () => {
-    const time = 1707775987656
-    const format = TimeFormat.MONTH_DATE
-    const result = formatTimestamp(time, format)
-    const date = new Date(time)
-    const expected = date.toLocaleDateString(undefined, {
-      month: 'short',
-      day: 'numeric',
-    })
-    expect(result).to.eq(expected)
   })
 })

--- a/cypress/unit/formatTimestampLabel.cy.ts
+++ b/cypress/unit/formatTimestampLabel.cy.ts
@@ -1,0 +1,31 @@
+import { formatTimestampLabel } from '../../src/components/helper'
+
+/* eslint-disable no-magic-numbers */
+describe('formatTimestampLabel function', () => {
+  it('returns formatted timestamp for time difference less than or equal to 1 day', () => {
+    const timestamp = 1709200800000
+    const timeDiffInDays = 0.5
+
+    const formattedLabel = formatTimestampLabel(timestamp, timeDiffInDays)
+
+    expect(formattedLabel).to.equal('2:00 AM')
+  })
+
+  it('returns formatted timestamp for time difference equal to 1 day', () => {
+    const timestamp = 1709200800000
+    const timeDiffInDays = 1
+
+    const formattedLabel = formatTimestampLabel(timestamp, timeDiffInDays)
+
+    expect(formattedLabel).to.equal('2:00 AM')
+  })
+
+  it('returns formatted timestamp for time difference more than 1 day', () => {
+    const timestamp = 1709200800000
+    const timeDiffInDays = 2
+
+    const formattedLabel = formatTimestampLabel(timestamp, timeDiffInDays)
+
+    expect(formattedLabel).to.equal('Feb 29')
+  })
+})

--- a/src/components/helper.ts
+++ b/src/components/helper.ts
@@ -87,3 +87,28 @@ export function formatTimestamp(
 
   return date.toLocaleString(userLocale, options)
 }
+
+export function calculateTimeDiffInDays(
+  startTimestampInMillis: number,
+  endTimestampInMillis: number
+): number {
+  const oneDay = 24 * 60 * 60 * 1000 // hours*minutes*seconds*milliseconds
+  const startDate = new Date(startTimestampInMillis)
+  const endDate = new Date(endTimestampInMillis)
+  const differenceInDays = Math.round(
+    Math.abs((endDate.getTime() - startDate.getTime()) / oneDay)
+  )
+
+  return differenceInDays
+}
+
+export function formatTimestampLabel(
+  timestampInMillis: number,
+  timeDiffInDays: number
+) {
+  if (timeDiffInDays <= 1) {
+    return formatTimestamp(timestampInMillis, TimeFormat.HOUR)
+  } else {
+    return formatTimestamp(timestampInMillis, TimeFormat.MONTH_DATE)
+  }
+}


### PR DESCRIPTION
## Changes
- Move time-related functions to the helper file and add tests 
- Update formatTimestamp test to test timestamp in milliseconds

## Screenshots
### Before
<img width="1023" alt="Screenshot 2024-02-29 at 4 28 46 PM" src="https://github.com/dragonscale-ai/ui-components/assets/103023797/88ca83e4-c9e4-45ce-9e29-f35856c2aa26">

### After
<img width="1023" alt="Screenshot 2024-02-29 at 4 28 46 PM" src="https://github.com/dragonscale-ai/ui-components/assets/103023797/ba6f035c-06b6-4ac1-8e70-4d33ff891548">


